### PR TITLE
.NET Core / ASP.NET Core 1.1.0 upgrade

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "samples" , "src" ],
     "sdk": {
-        "version": "1.0.0-preview2-003131"
+        "version": "1.0.0-preview2-1-003177"
     }
 }

--- a/samples/TestService/project.json
+++ b/samples/TestService/project.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.0.1-*",
+    "version": "1.1.0-*",
     "buildOptions": {
         "debugType": "portable",
         "emitEntryPoint": true
     },
     "dependencies": {
         "DasMulli.Win32.ServiceUtils": "1.0.1-*",
-        "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
-        "Microsoft.Extensions.Configuration.CommandLine": "1.0.0"
+        "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
+        "Microsoft.Extensions.Configuration.CommandLine": "1.1.0"
     },
     "frameworks": {
-        "netcoreapp1.0": {
+        "netcoreapp1.1": {
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.1"
+                    "version": "1.1.0"
                 }
             }
         }

--- a/test/DasMulli.Win32.ServiceUtils.Tests/project.json
+++ b/test/DasMulli.Win32.ServiceUtils.Tests/project.json
@@ -12,7 +12,7 @@
             "version": "10.2.1",
             "type": "build"
         },
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta4-build3444"
     },
     "testRunner": "xunit",
     "frameworks": {

--- a/test/DasMulli.Win32.ServiceUtils.Tests/project.json
+++ b/test/DasMulli.Win32.ServiceUtils.Tests/project.json
@@ -12,16 +12,25 @@
             "version": "10.2.1",
             "type": "build"
         },
-        "System.Runtime.Serialization.Primitives": "4.1.1",
         "xunit": "2.2.0-beta2-build3300"
     },
     "testRunner": "xunit",
     "frameworks": {
         "netcoreapp1.0": {
             "dependencies": {
+                "System.Runtime.Serialization.Primitives": "4.1.1",
                 "Microsoft.NETCore.App": {
                     "type": "platform",
                     "version": "1.0.1"
+                }
+            }
+        },
+        "netcoreapp1.1": {
+            "dependencies": {
+                "System.Runtime.Serialization.Primitives": "4.3.0",
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
                 }
             }
         },
@@ -29,6 +38,6 @@
             "frameworkAssemblies": {
                 "System.Runtime.Handles": {} 
             }
-        } 
+        }
     }
 }


### PR DESCRIPTION
Updates the SDK version, sample and test projects to `1.1.0` / `netstandard1.1`.
The test project keeps `netstandard1.0` additionally to make sure the lib can be restored, built and run properly when targeting .NET Core 1.0.