### PR TITLE
Update library and test dependencies to .NET Core 1.1 versions.

### DIFF
--- a/test/DasMulli.Win32.ServiceUtils.Tests/project.json
+++ b/test/DasMulli.Win32.ServiceUtils.Tests/project.json
@@ -6,8 +6,8 @@
     "dependencies": {
         "DasMulli.Win32.ServiceUtils": "1.0.1-*",
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "FakeItEasy": "2.4.0-netstd-build000033",
-        "FluentAssertions": "4.15.0",
+        "FakeItEasy": "3.0.0-beta002-build000066",
+        "FluentAssertions": "4.18.0",
         "JetBrains.Annotations": {
             "version": "10.2.1",
             "type": "build"


### PR DESCRIPTION
This pull request updates the core framework dependencies of ServiceUtils to their .NET Core 1.1 versions (4.0 → 4.3). Additionally, some dependencies of ServiceUtils.Tests are updated to ensure compatibility with the new core framework dependencies.