### PR TITLE
Stop service before deleting it to avoid "disabled" state and being able to recreate it without having to manually stop it.

### DIFF
--- a/src/DasMulli.Win32.ServiceUtils/INativeInterop.cs
+++ b/src/DasMulli.Win32.ServiceUtils/INativeInterop.cs
@@ -49,6 +49,8 @@ namespace DasMulli.Win32.ServiceUtils
 
         bool StartServiceW(ServiceHandle service, uint argc, IntPtr wargv);
 
+        bool StopService(ServiceHandle service);
+
         bool DeleteService(ServiceHandle service);
 
         bool ChangeServiceConfig2W(ServiceHandle service, ServiceConfigInfoTypeLevel infoTypeLevel, IntPtr info);

--- a/src/DasMulli.Win32.ServiceUtils/KnownWin32ErrorCodes.cs
+++ b/src/DasMulli.Win32.ServiceUtils/KnownWin32ErrorCodes.cs
@@ -6,5 +6,6 @@ namespace DasMulli.Win32.ServiceUtils
     internal static class KnownWin32ErrorCoes {
         internal const int ERROR_SERVICE_ALREADY_RUNNING = 1056;
         internal const int ERROR_SERVICE_DOES_NOT_EXIST = 1060;
+        internal const int ERROR_SERVICE_NOT_ACTIVE = 1062;
     }
 }

--- a/src/DasMulli.Win32.ServiceUtils/ServiceHandle.cs
+++ b/src/DasMulli.Win32.ServiceUtils/ServiceHandle.cs
@@ -43,6 +43,18 @@ namespace DasMulli.Win32.ServiceUtils
             }
         }
 
+        public virtual void Stop(bool throwIfAlreadyStopped = false)
+        {
+            if (!NativeInterop.StopService(this))
+            {
+                var win32Error = Marshal.GetLastWin32Error();
+                if (win32Error != KnownWin32ErrorCoes.ERROR_SERVICE_NOT_ACTIVE || throwIfAlreadyStopped)
+                {
+                    throw new Win32Exception(win32Error);
+                }
+            }
+        }
+
         public virtual void Delete()
         {
             if (!NativeInterop.DeleteService(this))

--- a/src/DasMulli.Win32.ServiceUtils/Win32Interop.cs
+++ b/src/DasMulli.Win32.ServiceUtils/Win32Interop.cs
@@ -80,6 +80,9 @@ namespace DasMulli.Win32.ServiceUtils
         private static extern bool StartServiceW(ServiceHandle service, uint argc, IntPtr wargv);
 
         [DllImport(DllServiceManagement_L1_1_0, ExactSpelling = true, SetLastError = true)]
+        private static extern bool ControlService(ServiceHandle service, uint argc, ref ServiceStatus serviceStatus);
+
+        [DllImport(DllServiceManagement_L1_1_0, ExactSpelling = true, SetLastError = true)]
         private static extern bool DeleteService(ServiceHandle service);
 
         [DllImport(DllServiceManagement_L2_1_0, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
@@ -134,6 +137,13 @@ namespace DasMulli.Win32.ServiceUtils
             bool INativeInterop.StartServiceW(ServiceHandle service, uint argc, IntPtr wargv)
             {
                 return StartServiceW(service, argc, wargv);
+            }
+
+            bool INativeInterop.StopService(ServiceHandle service)
+            {
+                const int SERVICE_CONTROL_STOP = 0x00000001;
+                var serviceStatus = new ServiceStatus();
+                return ControlService(service, SERVICE_CONTROL_STOP, ref serviceStatus);
             }
 
             bool INativeInterop.DeleteService(ServiceHandle service)

--- a/src/DasMulli.Win32.ServiceUtils/Win32ServiceManager.cs
+++ b/src/DasMulli.Win32.ServiceUtils/Win32ServiceManager.cs
@@ -212,6 +212,7 @@ namespace DasMulli.Win32.ServiceUtils
                 {
                     using (var svc = mgr.OpenService(serviceName, ServiceControlAccessRights.All))
                     {
+                        svc.Stop(); // stop before deleting to prevent staying in "disabled" state
                         svc.Delete();
                     }
                 }

--- a/test/DasMulli.Win32.ServiceUtils.Tests/SimpleServiceStateMachineTests.cs
+++ b/test/DasMulli.Win32.ServiceUtils.Tests/SimpleServiceStateMachineTests.cs
@@ -12,7 +12,7 @@ namespace DasMulli.Win32.ServiceUtils.Tests
         private static readonly string[] TestStartupArguments = new string[] { "Arg1", "Arg2" };
 
         private readonly ServiceStatusReportCallback statusReportCallback = A.Fake<ServiceStatusReportCallback>();
-        private readonly IWin32Service serviceImplmentation = A.Fake<IWin32Service>();
+        private readonly IWin32Service serviceImplementation = A.Fake<IWin32Service>();
 
         // subject under test
         private readonly IWin32ServiceStateMachine sut;
@@ -21,7 +21,7 @@ namespace DasMulli.Win32.ServiceUtils.Tests
 
         public SimpleServiceStateMachineTests()
         {
-            sut = new SimpleServiceStateMachine(serviceImplmentation);
+            sut = new SimpleServiceStateMachine(serviceImplementation);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace DasMulli.Win32.ServiceUtils.Tests
             sut.OnStart(TestStartupArguments, statusReportCallback);
 
             // Then
-            A.CallTo(() => serviceImplmentation.Start(TestStartupArguments, A<ServiceStoppedCallback>._)).MustHaveHappened();
+            A.CallTo(() => serviceImplementation.Start(TestStartupArguments, A<ServiceStoppedCallback>._)).MustHaveHappened();
             A.CallTo(() => statusReportCallback(ServiceState.Running, ServiceAcceptedControlCommandsFlags.Stop, 0, 0)).MustHaveHappened();
         }
 
@@ -45,7 +45,7 @@ namespace DasMulli.Win32.ServiceUtils.Tests
             sut.OnCommand(ServiceControlCommand.Stop, 0);
 
             // Then
-            A.CallTo(() => serviceImplmentation.Stop()).MustHaveHappened();
+            A.CallTo(() => serviceImplementation.Stop()).MustHaveHappened();
             A.CallTo(() => statusReportCallback(ServiceState.Stopped, ServiceAcceptedControlCommandsFlags.None, 0, 0)).MustHaveHappened();
         }
 
@@ -53,7 +53,7 @@ namespace DasMulli.Win32.ServiceUtils.Tests
         public void ItShallReportStoppedImplmentationThrowsOnStartup()
         {
             // Given
-            A.CallTo(serviceImplmentation).Throws<Exception>();
+            A.CallTo(serviceImplementation).Throws<Exception>();
 
             // When
             sut.OnStart(TestStartupArguments, statusReportCallback);
@@ -68,7 +68,7 @@ namespace DasMulli.Win32.ServiceUtils.Tests
         {
             // Given
             GivenTheServiceHasBeenStarted();
-            A.CallTo(serviceImplmentation).Throws<Exception>();
+            A.CallTo(serviceImplementation).Throws<Exception>();
 
             // When
             sut.OnCommand(ServiceControlCommand.Stop, 0);
@@ -103,12 +103,12 @@ namespace DasMulli.Win32.ServiceUtils.Tests
 
             // Then no other calls than the startup calls must have been made
             A.CallTo(statusReportCallback).MustHaveHappened(Repeated.NoMoreThan.Once);
-            A.CallTo(serviceImplmentation).MustHaveHappened(Repeated.NoMoreThan.Once);
+            A.CallTo(serviceImplementation).MustHaveHappened(Repeated.NoMoreThan.Once);
         }
 
         private void GivenTheServiceHasBeenStarted()
         {
-            A.CallTo(() => serviceImplmentation.Start(null, null))
+            A.CallTo(() => serviceImplementation.Start(null, null))
                 .WithAnyArguments()
                 .Invokes((string[] args, ServiceStoppedCallback stoppedCallback) =>
                 {


### PR DESCRIPTION
Call the StopService() method prior to unistalling the service in Win32ServiceManager to prevent it staying in "disabled" state until someone stops the service (which might never happen). If not doing that, we cannot then install the service.
Add a Stop() method to ServiceHandle class.
Add a StopService() method to INativeInterop (implemented in Win32Interop).
Add ControlService() function to Win32Interop file.
